### PR TITLE
Fix PWA navigation to always stay on /gredez/

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -9,8 +9,7 @@
         const query = window.location.search;
         
         // Store the full URL in session storage and redirect to index.html
-        const repositoryName = location.pathname.split('/')[1];
-        const basePath = repositoryName ? '/' + repositoryName : '';
+        const basePath = '/gredez';
         sessionStorage.setItem('redirectPath', path);
         window.location.replace(basePath + '/index.html' + query);
     </script>

--- a/src/index.html
+++ b/src/index.html
@@ -8,8 +8,7 @@
     <script>
         // Get base path from repository name
         const getBasePath = () => {
-            const repositoryName = location.pathname.split('/')[1];
-            return repositoryName ? '/' + repositoryName : '';
+            return '/gredez';
         };
         // Add base path to all asset URLs
         window.__basePath = getBasePath();

--- a/src/js/PageManager.js
+++ b/src/js/PageManager.js
@@ -48,17 +48,20 @@ export default class PageManager {
 
   // Internal method to normalize route paths
   normalizeRoute(route) {
-    // Remove the repository name if present
-    const basePath = window.__basePath || '';
-    route = route.replace(basePath, '');
-    
     // Ensure route starts with '/' and remove any trailing '/'
-    return '/' + route.replace(/^\/+|\/+$/g, '');
+    route = '/' + route.replace(/^\/+|\/+$/g, '');
+    
+    // Add the base path if not already included
+    const basePath = '/gredez';
+    if (!route.startsWith(basePath)) {
+      route = basePath + route;
+    }
+    
+    return route;
   }
 
   // Get full path including repository name
   getFullPath(route) {
-    const basePath = window.__basePath || '';
-    return basePath + this.normalizeRoute(route);
+    return this.normalizeRoute(route);
   }
 }


### PR DESCRIPTION
Fix navigation to always stay on `https://maksm.github.io/gredez/` and its pages.

* **404.html**
  - Update `basePath` calculation to always include `/gredez`.
  - Ensure redirection URL includes the base path.

* **index.html**
  - Update `getBasePath` function to always include `/gredez`.

* **PageManager.js**
  - Update `normalizeRoute` function to ensure the base path is always included in routes.
  - Ensure `getFullPath` function includes the base path.

* **sw.js**
  - Update fetch event handler to include the base path in requests.
  - Modify image request handling to include the base path.
  - Update cache handling to include the base path in requests.

